### PR TITLE
Fix the blank line in templates if data doesn't exist in variable or is empty;

### DIFF
--- a/stubs/patch/data_patch.stub
+++ b/stubs/patch/data_patch.stub
@@ -1,5 +1,7 @@
 <?php
+{{# file_annotation }}
 {{{ file_annotation }}}
+{{/ file_annotation }}
 
 declare(strict_types = 1);
 
@@ -8,7 +10,9 @@ namespace {{{ file_namespace }}};
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 
+{{# class_annotation }}
 {{{ class_annotation }}}
+{{/ class_annotation }}
 class {{{ class_name }}} implements DataPatchInterface
 {
     protected ModuleDataSetupInterface $moduleDataSetup;


### PR DESCRIPTION
## Fix the blank line in templates if data doesn't exist in variable or is empty;

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Type          | bugfix             |
| License       | MIT                                                         |

### Summary (*)

Fixed template `stubs/patch/data_patch.stub`:

```twig
{{# file_annotation }}
{{{ file_annotation }}}
{{/ file_annotation }}

declare(strict_types = 1);

namespace {{{ file_namespace }}};

use Magento\Framework\Setup\ModuleDataSetupInterface;
use Magento\Framework\Setup\Patch\DataPatchInterface;

{{# class_annotation }}
{{{ class_annotation }}}
{{/ class_annotation }}
```

As you can see I replaced simple variable render `{{{ var }}}` into the render with if statement:

```twig
{{# class_annotation }}
{{{ class_annotation }}}
{{/ class_annotation }}
```

In that case **mustache** engine does not create blank line if variable is empty.

Good for me, despite it makes the template more complex that should.

👍🏻 
