### PR TITLE
The file writer should ask for file rewrite if it exists.

### DIFF
--- a/Api/Data/Command/InterruptInterface.php
+++ b/Api/Data/Command/InterruptInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Api\Data\Command;
+
+use Magento\Framework\Phrase;
+
+interface InterruptInterface
+{
+    /**
+     * Interrupts stream and ask for confirmation.
+     *
+     * @param Phrase $question
+     *
+     * @return bool
+     */
+    public function ask(Phrase $question): bool;
+
+    /**
+     * Sends information message into output.
+     *
+     * @param Phrase $information
+     *
+     * @return void
+     */
+    public function info(Phrase $information): void;
+}

--- a/Api/Data/Context/ContextInterface.php
+++ b/Api/Data/Context/ContextInterface.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Api\Data\Context;
 
+use Marsskom\Generator\Api\Data\Command\InterruptInterface;
 use Marsskom\Generator\Api\Data\Template\TemplateInterface;
 
 interface ContextInterface
@@ -32,7 +33,7 @@ interface ContextInterface
      * @return ContextInterface
      */
     public function setVariables(array $variables): ContextInterface;
-    
+
     /**
      * Returns template variables.
      *
@@ -78,4 +79,11 @@ interface ContextInterface
      * @return array<string, string>
      */
     public function getUserInput(): array;
+
+    /**
+     * Returns interrupt object.
+     *
+     * @return InterruptInterface
+     */
+    public function interrupt(): InterruptInterface;
 }

--- a/Model/Console/Interrupt.php
+++ b/Model/Console/Interrupt.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Console;
+
+use Magento\Framework\Phrase;
+use Marsskom\Generator\Api\Data\Command\InterruptInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class Interrupt implements InterruptInterface
+{
+    private InputInterface $input;
+
+    private OutputInterface $output;
+
+    /**
+     * Interrupt constructor.
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     */
+    public function __construct(
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        $this->input = $input;
+        $this->output = $output;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function ask(Phrase $question): bool
+    {
+        return (new QuestionHelper())
+            ->ask($this->input, $this->output, new ConfirmationQuestion((string) $question));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function info(Phrase $information): void
+    {
+        $this->output->writeln((string) $information);
+    }
+}

--- a/Model/Context/Context.php
+++ b/Model/Context/Context.php
@@ -4,12 +4,15 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Model\Context;
 
+use Marsskom\Generator\Api\Data\Command\InterruptInterface;
 use Marsskom\Generator\Api\Data\Context\ContextInterface;
 use Marsskom\Generator\Api\Data\Template\TemplateInterface;
 
 class Context implements ContextInterface
 {
     private TemplateInterface $template;
+
+    private InterruptInterface $interrupt;
 
     private string $path;
 
@@ -22,21 +25,24 @@ class Context implements ContextInterface
     /**
      * Context constructor.
      *
-     * @param TemplateInterface $template
-     * @param string            $path
-     * @param string            $fileName
-     * @param array             $userInput
+     * @param TemplateInterface  $template
+     * @param InterruptInterface $interrupt
+     * @param string             $path
+     * @param string             $fileName
+     * @param array              $userInput
      */
     public function __construct(
         TemplateInterface $template,
+        InterruptInterface $interrupt,
         string $path = '',
         string $fileName = '',
         array $userInput = []
     ) {
+        $this->template = $template;
+        $this->interrupt = $interrupt;
         $this->path = $path;
         $this->fileName = $fileName;
         $this->userInput = $userInput;
-        $this->template = $template;
     }
 
     /**
@@ -117,5 +123,13 @@ class Context implements ContextInterface
     public function getUserInput(): array
     {
         return $this->userInput;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function interrupt(): InterruptInterface
+    {
+        return $this->interrupt;
     }
 }

--- a/Test/Unit/Foundation/SequenceTest.php
+++ b/Test/Unit/Foundation/SequenceTest.php
@@ -4,17 +4,40 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Test\Unit\Foundation;
 
-use Marsskom\Generator\Api\Data\Template\TemplateInterface;
-use Marsskom\Generator\Model\Context\Context;
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Test\Unit\Mock\Automation\MultiplierGenerator;
 use Marsskom\Generator\Test\Unit\Mock\Sequence\SimpleSequence;
 use Marsskom\Generator\Test\Unit\Mock\TemplateEngine\TemplateFromArray;
+use Marsskom\Generator\Test\Unit\MockHelper\ContextFactory;
 use PHPUnit\Framework\TestCase;
 use function implode;
 
 class SequenceTest extends TestCase
 {
+    private ContextInterface $context;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->context = (new ContextFactory())->getMockedContext(
+            [
+                InputParameter::MODULE => '',
+                InputParameter::PATH   => '',
+            ]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown(): void
+    {
+        unset($this->context);
+    }
+
     /**
      * Tests generator queue.
      *
@@ -24,18 +47,8 @@ class SequenceTest extends TestCase
     {
         $string = '0123456789';
 
-        $context = new Context(
-            $this->createMock(TemplateInterface::class),
-            '',
-            '',
-            [
-                InputParameter::MODULE => '',
-                InputParameter::PATH   => '',
-            ]
-        );
-
         $sequence = new SimpleSequence($string);
-        $context = $sequence->execute($context);
+        $context = $sequence->execute($this->context);
 
         $this->assertEquals(
             $string,
@@ -52,18 +65,10 @@ class SequenceTest extends TestCase
     {
         $string = '9876543210';
 
-        $context = new Context(
-            new TemplateFromArray(),
-            '',
-            '',
-            [
-                InputParameter::MODULE => '',
-                InputParameter::PATH   => '',
-            ]
-        );
-
         $sequence = new SimpleSequence($string);
-        $context = $sequence->execute($context);
+        $context = $sequence->execute(
+            $this->context->setTemplate(new TemplateFromArray())
+        );
 
         $this->assertEquals(
             $string,
@@ -80,21 +85,13 @@ class SequenceTest extends TestCase
     {
         $string = '1234567890';
 
-        $context = new Context(
-            new TemplateFromArray(),
-            '',
-            '',
-            [
-                InputParameter::MODULE => '',
-                InputParameter::PATH   => '',
-            ]
-        );
-
         $sequence = new SimpleSequence(
             $string,
             [new MultiplierGenerator(2)]
         );
-        $context = $sequence->execute($context);
+        $context = $sequence->execute(
+            $this->context->setTemplate(new TemplateFromArray())
+        );
 
         $this->assertEquals(
             '246810121416180',

--- a/Test/Unit/MockHelper/ContextFactory.php
+++ b/Test/Unit/MockHelper/ContextFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Test\Unit\MockHelper;
+
+use Marsskom\Generator\Api\Data\Command\InterruptInterface;
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Api\Data\Template\TemplateInterface;
+use Marsskom\Generator\Model\Context\Context;
+use PHPUnit\Framework\TestCase;
+
+class ContextFactory extends TestCase
+{
+    /**
+     * Returns mocked context.
+     *
+     * @param array $userInput
+     *
+     * @return ContextInterface
+     */
+    public function getMockedContext(array $userInput): ContextInterface
+    {
+        return new Context(
+            $this->createMock(TemplateInterface::class),
+            $this->createMock(InterruptInterface::class),
+            '',
+            '',
+            $userInput
+        );
+    }
+}

--- a/Test/Unit/Stub/Automation/FileNameAssignerTest.php
+++ b/Test/Unit/Stub/Automation/FileNameAssignerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Test\Unit\Stub\Automation;
 
+use Marsskom\Generator\Api\Data\Command\InterruptInterface;
 use Marsskom\Generator\Api\Data\Template\TemplateInterface;
 use Marsskom\Generator\Model\Context\Context;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\FileNameAssigner;
@@ -20,7 +21,10 @@ class FileNameAssignerTest extends TestCase
     {
         $fileName = 'file.dot';
 
-        $context = new Context($this->createMock(TemplateInterface::class));
+        $context = new Context(
+            $this->createMock(TemplateInterface::class),
+            $this->createMock(InterruptInterface::class)
+        );
         $fileNameAssigner = new FileNameAssigner($fileName);
 
         $context = $fileNameAssigner->execute($context);

--- a/Test/Unit/Stub/Automation/NamespaceGeneratorTest.php
+++ b/Test/Unit/Stub/Automation/NamespaceGeneratorTest.php
@@ -4,13 +4,12 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Test\Unit\Stub\Automation;
 
-use Marsskom\Generator\Api\Data\Template\TemplateInterface;
-use Marsskom\Generator\Model\Context\Context;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Enum\TemplateVariable;
 use Marsskom\Generator\Model\Helper\Builder\ModuleBuilder;
 use Marsskom\Generator\Model\Helper\Module;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
+use Marsskom\Generator\Test\Unit\MockHelper\ContextFactory;
 use PHPUnit\Framework\TestCase;
 
 class NamespaceGeneratorTest extends TestCase
@@ -22,18 +21,14 @@ class NamespaceGeneratorTest extends TestCase
      */
     public function testExecute(): void
     {
-        $context = new Context(
-            $this->createMock(TemplateInterface::class),
-            '',
-            '',
-            [
+        $namespaceGenerator = new NamespaceGenerator($this->getModuleBuilderMockedObject());
+
+        $context = $namespaceGenerator->execute(
+            (new ContextFactory())->getMockedContext([
                 InputParameter::MODULE => 'Test_test',
                 InputParameter::PATH   => 'path/to/file',
-            ]
+            ])
         );
-
-        $namespaceGenerator = new NamespaceGenerator($this->getModuleBuilderMockedObject());
-        $namespaceGenerator->execute($context);
 
         $this->assertEquals(
             'Test\\test\\path\\to\\file',

--- a/Test/Unit/Stub/Automation/PathAssignerTest.php
+++ b/Test/Unit/Stub/Automation/PathAssignerTest.php
@@ -6,11 +6,10 @@ namespace Marsskom\Generator\Test\Unit\Stub\Automation;
 
 use Magento\Framework\Exception\FileSystemException;
 use Marsskom\Generator\Api\Data\Context\ContextInterface;
-use Marsskom\Generator\Api\Data\Template\TemplateInterface;
-use Marsskom\Generator\Model\Context\Context;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\PathAssigner;
 use Marsskom\Generator\Test\Unit\Mock\Helper\Path;
+use Marsskom\Generator\Test\Unit\MockHelper\ContextFactory;
 use PHPUnit\Framework\TestCase;
 use function implode;
 use function rtrim;
@@ -26,15 +25,10 @@ class PathAssignerTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->context = new Context(
-            $this->createMock(TemplateInterface::class),
-            '',
-            '',
-            [
-                InputParameter::MODULE => 'Test_test',
-                InputParameter::PATH   => 'path/to/file',
-            ]
-        );
+        $this->context = (new ContextFactory())->getMockedContext([
+            InputParameter::MODULE => 'Test_test',
+            InputParameter::PATH   => 'path/to/file',
+        ]);
     }
 
     /**

--- a/Test/Unit/Stub/Automation/PathGeneratorTest.php
+++ b/Test/Unit/Stub/Automation/PathGeneratorTest.php
@@ -5,11 +5,10 @@ declare(strict_types = 1);
 namespace Marsskom\Generator\Test\Unit\Stub\Automation;
 
 use Magento\Framework\Exception\FileSystemException;
-use Marsskom\Generator\Api\Data\Template\TemplateInterface;
-use Marsskom\Generator\Model\Context\Context;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\PathGenerator;
 use Marsskom\Generator\Test\Unit\Mock\Helper\Path;
+use Marsskom\Generator\Test\Unit\MockHelper\ContextFactory;
 use PHPUnit\Framework\TestCase;
 use function implode;
 use function rtrim;
@@ -27,19 +26,14 @@ class PathGeneratorTest extends TestCase
      */
     public function testModulePath(): void
     {
-        $context = new Context(
-            $this->createMock(TemplateInterface::class),
-            '',
-            '',
-            [
-                InputParameter::MODULE => 'Test_test',
-                InputParameter::PATH   => '',
-            ]
-        );
-
         $pathGenerator = new PathGenerator(new Path());
 
-        $context = $pathGenerator->execute($context);
+        $context = $pathGenerator->execute(
+            (new ContextFactory())->getMockedContext([
+                InputParameter::MODULE => 'Test_test',
+                InputParameter::PATH   => '',
+            ])
+        );
 
         $expectedPath = implode(
             DIRECTORY_SEPARATOR,
@@ -64,19 +58,14 @@ class PathGeneratorTest extends TestCase
      */
     public function testDirectoryPath(): void
     {
-        $context = new Context(
-            $this->createMock(TemplateInterface::class),
-            '',
-            '',
-            [
-                InputParameter::MODULE => 'Test_test',
-                InputParameter::PATH   => 'path/to/file',
-            ]
-        );
-
         $pathGenerator = new PathGenerator(new Path());
 
-        $context = $pathGenerator->execute($context);
+        $context = $pathGenerator->execute(
+            (new ContextFactory())->getMockedContext([
+                InputParameter::MODULE => 'Test_test',
+                InputParameter::PATH   => 'path/to/file',
+            ])
+        );
 
         $expectedPath = implode(
             DIRECTORY_SEPARATOR,

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,6 +3,8 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Marsskom\Generator\Api\Data\Context\ContextInterface"
                 type="Marsskom\Generator\Model\Context\Context"/>
+    <preference for="Marsskom\Generator\Api\Data\Command\InterruptInterface"
+                type="Marsskom\Generator\Model\Console\Interrupt"/>
     <preference for="Marsskom\Generator\Api\Data\Helper\PathInterface"
                 type="Marsskom\Generator\Model\Helper\Path"/>
 


### PR DESCRIPTION
## The file writer should ask for file rewrite if it exists.

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Type          | feature             |
| License       | MIT                                                         |

### Summary (*)

+ Added `InterruptInterface` that keeps `input` and `output` context; Commonly it is symfony console interfaces,
	however they could be changed by custom classes.
+ Added `interrupt` to `context`. Yes, I know that it is not good for context class size, but it is OK for now.
	You can ask, why context interrupts the generator's sequence? Because here context represents the context
	of execution from **command** to **generator**.
+ Updated tests according to `context` updates.

- There is `ContextFactory` that I added. It is just a helper, but extends the `TestCase` class
	so **phpunit** thinks this class is for tests, but it isn't. The problem is in that I need
	`createMock` method which is *protected* in `TestCase`.

