### PR TITLE
Let's try to disable the shared type for validators instead of factories usage. #38

### DIFF
--- a/Model/Validator/Observer/Command/DataPatchObserver.php
+++ b/Model/Validator/Observer/Command/DataPatchObserver.php
@@ -5,8 +5,8 @@ declare(strict_types = 1);
 namespace Marsskom\Generator\Model\Validator\Observer\Command;
 
 use Marsskom\Generator\Console\Command\Patch\DataPatchCommand;
-use Marsskom\Generator\Model\Validator\Console\ModuleValidatorFactory;
-use Marsskom\Generator\Model\Validator\Console\NameValidatorFactory;
+use Marsskom\Generator\Model\Validator\Console\ModuleValidator;
+use Marsskom\Generator\Model\Validator\Console\NameValidator;
 use Marsskom\Generator\Model\Validator\ValidatorObserver;
 use Marsskom\Generator\Model\Validator\ValidatorResultBuilder;
 
@@ -15,17 +15,17 @@ class DataPatchObserver extends ValidatorObserver
     /**
      * @inheritdoc
      *
-     * @param ModuleValidatorFactory $moduleFactory
-     * @param NameValidator          $nameFactory
+     * @param ModuleValidator $moduleValidator
+     * @param NameValidator   $nameValidator
      */
     public function __construct(
         ValidatorResultBuilder $resultBuilder,
-        ModuleValidatorFactory $moduleFactory,
-        NameValidatorFactory $nameFactory
+        ModuleValidator $moduleValidator,
+        NameValidator $nameValidator
     ) {
         parent::__construct($resultBuilder);
 
-        $this->attach(DataPatchCommand::EVENT_NAME, $moduleFactory->create());
-        $this->attach(DataPatchCommand::EVENT_NAME, $nameFactory->create());
+        $this->attach(DataPatchCommand::EVENT_NAME, $moduleValidator);
+        $this->attach(DataPatchCommand::EVENT_NAME, $nameValidator);
     }
 }

--- a/Model/Validator/Observer/ModuleObserver.php
+++ b/Model/Validator/Observer/ModuleObserver.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Marsskom\Generator\Model\Validator\Observer;
 
 use Marsskom\Generator\Console\Command\ModuleCommand;
-use Marsskom\Generator\Model\Validator\Console\ModuleValidatorFactory;
+use Marsskom\Generator\Model\Validator\Console\ModuleValidator;
 use Marsskom\Generator\Model\Validator\ValidatorObserver;
 use Marsskom\Generator\Model\Validator\ValidatorResultBuilder;
 
@@ -14,14 +14,14 @@ class ModuleObserver extends ValidatorObserver
     /**
      * @inheritdoc
      *
-     * @param ModuleValidator $moduleFactory
+     * @param ModuleValidator $moduleValidator
      */
     public function __construct(
         ValidatorResultBuilder $resultBuilder,
-        ModuleValidatorFactory $moduleFactory
+        ModuleValidator $moduleValidator
     ) {
         parent::__construct($resultBuilder);
 
-        $this->attach(ModuleCommand::EVENT_NAME, $moduleFactory->create());
+        $this->attach(ModuleCommand::EVENT_NAME, $moduleValidator);
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,6 +18,9 @@
     <preference for="Marsskom\Generator\Api\Data\Validator\ValidationObserverInterface"
                 type="Marsskom\Generator\Model\Validator\ValidatorObserver"/>
 
+    <type name="Marsskom\Generator\Model\Validator\Console\ModuleValidator" shared="false"/>
+    <type name="Marsskom\Generator\Model\Validator\Console\NameValidator" shared="false"/>
+
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
## Let's try to disable the shared type for validators instead of factories usage.

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Type          | bugfix/feature             |
| License       | OSL 3.0                                                         |


### Summary (*)

+ Replaced validators' factories with validators' objects.

+ Added `shared="false"` for default validators.
	All validators should be created with `shared="false"` further.
