### PR TITLE
 Entity generator #10 

### DIFF
--- a/Api/Data/Input/ParserInterface.php
+++ b/Api/Data/Input/ParserInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Api\Data\Input;
+
+interface ParserInterface
+{
+    /**
+     * Parses input value and return a result.
+     *
+     * @param string $inputValue
+     *
+     * @return mixed
+     */
+    public function parse(string $inputValue);
+}

--- a/Console/Command/Console/ConsoleCommandCommand.php
+++ b/Console/Command/Console/ConsoleCommandCommand.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Marsskom\Generator\Console\Command\Console;
 
 use Marsskom\Generator\Console\Command\GeneratorCommand;
+use Marsskom\Generator\Model\Context\ContextBuilder;
+use Marsskom\Generator\Model\Manager\Console\CommandManager;
 
 class ConsoleCommandCommand extends GeneratorCommand
 {
@@ -13,6 +15,19 @@ class ConsoleCommandCommand extends GeneratorCommand
     public const COMMAND_NAME_PARAMETER = 'cname';
 
     public const COMMAND_DESC_PARAMETER = 'cdesc';
+
+    /**
+     * @inheritdoc
+     *
+     * @param CommandManager $commandManager
+     */
+    public function __construct(
+        CommandManager $commandManager,
+        ContextBuilder $contextBuilder,
+        string $name = null
+    ) {
+        parent::__construct($commandManager, $contextBuilder, $name);
+    }
 
     /**
      * @inheritdoc

--- a/Console/Command/EntityCommand.php
+++ b/Console/Command/EntityCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Console\Command;
+
+class EntityCommand extends GeneratorCommand
+{
+    public const EVENT_NAME = 'console_command_entity-command';
+    
+    public const COMMAND_HAS_INTERFACE_PARAMETER = 'i';
+    
+    public const COMMAND_IS_DATA_OBJECT_PARAMETER = 'do';
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure(): void
+    {
+        $this->setName('generate:entity');
+        $this->setDescription("Generates entity.");
+
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getEventName(): string
+    {
+        return self::EVENT_NAME;
+    }
+}

--- a/Console/Command/EntityCommand.php
+++ b/Console/Command/EntityCommand.php
@@ -4,13 +4,29 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Console\Command;
 
+use Marsskom\Generator\Model\Context\ContextBuilder;
+use Marsskom\Generator\Model\Manager\EntityManager;
+
 class EntityCommand extends GeneratorCommand
 {
     public const EVENT_NAME = 'console_command_entity-command';
-    
+
     public const COMMAND_HAS_INTERFACE_PARAMETER = 'i';
-    
+
     public const COMMAND_IS_DATA_OBJECT_PARAMETER = 'do';
+
+    /**
+     * @inheritdoc
+     *
+     * @param EntityManager $entityManager
+     */
+    public function __construct(
+        EntityManager $entityManager,
+        ContextBuilder $contextBuilder,
+        string $name = null
+    ) {
+        parent::__construct($entityManager, $contextBuilder, $name);
+    }
 
     /**
      * @inheritdoc

--- a/Console/Command/ModuleCommand.php
+++ b/Console/Command/ModuleCommand.php
@@ -4,9 +4,25 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Console\Command;
 
+use Marsskom\Generator\Model\Context\ContextBuilder;
+use Marsskom\Generator\Model\Manager\ModuleManager;
+
 class ModuleCommand extends GeneratorCommand
 {
     public const EVENT_NAME = 'console_command_module-command';
+
+    /**
+     * @inheritdoc
+     *
+     * @param ModuleManager $moduleManager
+     */
+    public function __construct(
+        ModuleManager $moduleManager,
+        ContextBuilder $contextBuilder,
+        string $name = null
+    ) {
+        parent::__construct($moduleManager, $contextBuilder, $name);
+    }
 
     /**
      * @inheritdoc

--- a/Console/Command/Patch/DataPatchCommand.php
+++ b/Console/Command/Patch/DataPatchCommand.php
@@ -5,10 +5,25 @@ declare(strict_types = 1);
 namespace Marsskom\Generator\Console\Command\Patch;
 
 use Marsskom\Generator\Console\Command\GeneratorCommand;
+use Marsskom\Generator\Model\Context\ContextBuilder;
+use Marsskom\Generator\Model\Manager\Patch\DataPatchManager;
 
 class DataPatchCommand extends GeneratorCommand
 {
     public const EVENT_NAME = 'console_command_data-patch-command';
+
+    /**
+     * @inheritdoc
+     *
+     * @param DataPatchManager $dataPatchManager
+     */
+    public function __construct(
+        DataPatchManager $dataPatchManager,
+        ContextBuilder $contextBuilder,
+        string $name = null
+    ) {
+        parent::__construct($dataPatchManager, $contextBuilder, $name);
+    }
 
     /**
      * @inheritdoc

--- a/Exception/Entity/PropertyStringIsInvalid.php
+++ b/Exception/Entity/PropertyStringIsInvalid.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Exception\Entity;
+
+use Magento\Framework\Exception\LocalizedException;
+
+class PropertyStringIsInvalid extends LocalizedException
+{
+}

--- a/Model/Context/Buffer.php
+++ b/Model/Context/Buffer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Context;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+
+class Buffer
+{
+    private ContextInterface $originalContext;
+
+    /**
+     * Buffer constructor.
+     *
+     * @param ContextInterface $context
+     */
+    public function __construct(
+        ContextInterface $context
+    ) {
+        $this->originalContext = clone $context;
+    }
+
+    /**
+     * Returns original context.
+     *
+     * @return ContextInterface
+     */
+    public function restore(): ContextInterface
+    {
+        return $this->originalContext;
+    }
+}

--- a/Model/Context/BufferBuilder.php
+++ b/Model/Context/BufferBuilder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Context;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+
+class BufferBuilder
+{
+    /**
+     * Returns buffer.
+     *
+     * @param ContextInterface $context
+     *
+     * @return Buffer
+     */
+    public function create(ContextInterface $context): Buffer
+    {
+        return new Buffer($context);
+    }
+}

--- a/Model/Context/Context.php
+++ b/Model/Context/Context.php
@@ -132,4 +132,15 @@ class Context implements ContextInterface
     {
         return $this->interrupt;
     }
+
+    /**
+     * Clone method.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        $this->template = clone $this->template;
+        $this->interrupt = clone $this->interrupt;
+    }
 }

--- a/Model/Entity/Property.php
+++ b/Model/Entity/Property.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Entity;
+
+class Property
+{
+    private string $name;
+
+    /**
+     * @var string[]
+     */
+    private array $types;
+
+    private bool $hasSetter;
+
+    private bool $hasGetter;
+
+    /**
+     * Property constructor.
+     *
+     * @param string   $name
+     * @param string[] $types
+     * @param bool     $hasSetter
+     * @param bool     $hasGetter
+     */
+    public function __construct(
+        string $name,
+        array $types,
+        bool $hasSetter,
+        bool $hasGetter
+    ) {
+        $this->name = $name;
+        $this->types = $types;
+        $this->hasSetter = $hasSetter;
+        $this->hasGetter = $hasGetter;
+    }
+
+    /**
+     * Returns property name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns property types.
+     *
+     * @return string[]
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * Returns "has setter" state.
+     *
+     * @return bool
+     */
+    public function hasSetter(): bool
+    {
+        return $this->hasSetter;
+    }
+
+    /**
+     * Returns "has getter" state.
+     *
+     * @return bool
+     */
+    public function hasGetter(): bool
+    {
+        return $this->hasGetter;
+    }
+}

--- a/Model/Enum/InputParameter.php
+++ b/Model/Enum/InputParameter.php
@@ -13,12 +13,17 @@ final class InputParameter
     public const MODULE = 'module';
 
     /**
+     * File location.
+     */
+    public const PATH = 'path';
+
+    /**
      * Filename or/and classname.
      */
     public const NAME = 'name';
 
     /**
-     * File location.
+     * Class properties.
      */
-    public const PATH = 'path';
+    public const PROPERTIES = 'props';
 }

--- a/Model/Enum/TemplateVariable.php
+++ b/Model/Enum/TemplateVariable.php
@@ -7,13 +7,27 @@ namespace Marsskom\Generator\Model\Enum;
 // phpcs:disable Magento2.PHP.FinalImplementation
 final class TemplateVariable
 {
+    public const MODULE_NAME = 'module_name';
+
     public const FILE_ANNOTATION = 'file_annotation';
 
     public const FILE_NAMESPACE = 'file_namespace';
 
+    public const FILE_USES = 'file_uses';
+
     public const CLASS_ANNOTATION = 'class_annotation';
 
     public const CLASS_NAME = 'class_name';
-    
-    public const MODULE_NAME = 'module_name';
+
+    public const CLASS_EXTENDS = 'class_extends';
+
+    public const CLASS_IMPLEMENTS = 'class_implements';
+
+    public const CLASS_PROPERTIES = 'class_properties';
+
+    public const INTERFACE_ANNOTATION = 'interface_annotation';
+
+    public const INTERFACE_NAME = 'interface_name';
+
+    public const METHODS = 'methods';
 }

--- a/Model/Foundation/BufferedSequence.php
+++ b/Model/Foundation/BufferedSequence.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Foundation;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Model\Context\BufferBuilder;
+
+class BufferedSequence extends Sequence
+{
+    private BufferBuilder $bufferBuilder;
+
+    /**
+     * Buffered sequence constructor.
+     *
+     * @param BufferBuilder $bufferBuilder
+     * @param array         $sequences
+     */
+    public function __construct(
+        BufferBuilder $bufferBuilder,
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->bufferBuilder = $bufferBuilder;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        $buffer = $this->bufferBuilder->create($context);
+
+        parent::execute($context);
+
+        return $buffer->restore();
+    }
+}

--- a/Model/InputOption/Entity/PropertiesOption.php
+++ b/Model/InputOption/Entity/PropertiesOption.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\InputOption\Entity;
+
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Symfony\Component\Console\Input\InputOption;
+
+class PropertiesOption extends InputOption
+{
+    /**
+     * Creates input option.
+     *
+     * @return PropertiesOption
+     * phpcs:disable Magento2.Functions.StaticFunction
+     */
+    public static function create(): PropertiesOption
+    {
+        return new PropertiesOption(
+            InputParameter::PROPERTIES,
+            null,
+            InputOption::VALUE_OPTIONAL,
+            <<<TEXT
+            Example value: "id:int|null:sg;name:NameInterface:g"
+
+            ---
+
+            What that means:
+
+            %property_name%
+            : - delimiter
+            %type%
+            | - type delimiter
+            %another_type% - optional
+            : - delimiter
+            sg - s is setter; g - getter; both are optional
+            ; - delimiter between properties
+            
+            ... etc, same from the start ...
+            
+            ---
+
+            It converts into two properties `id` and `name`.
+            `id` with type **int** or **null** and `name` - **NameInterface**
+
+            Also for `id` parameter getter and setter will be created.
+            For `name` - only getter. If you need only setter, set `s` after property type.
+            TEXT
+        );
+    }
+}

--- a/Model/InputParser/Entity/PropertiesParser.php
+++ b/Model/InputParser/Entity/PropertiesParser.php
@@ -143,6 +143,10 @@ class PropertiesParser implements ParserInterface
      */
     protected function validate(string $inputString): bool
     {
+        if ('?' === $inputString) {
+            return true;
+        }
+
         return (bool) preg_match('/^[A-Za-z]\w+?$/', $inputString);
     }
 }

--- a/Model/InputParser/Entity/PropertiesParser.php
+++ b/Model/InputParser/Entity/PropertiesParser.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\InputParser\Entity;
+
+use Marsskom\Generator\Api\Data\Input\ParserInterface;
+use Marsskom\Generator\Exception\Entity\PropertyStringIsInvalid;
+use Marsskom\Generator\Model\Entity\Property;
+use function array_filter;
+use function array_map;
+use function explode;
+use function strpos;
+
+class PropertiesParser implements ParserInterface
+{
+    public const PROPERTY_DELIMITER = ';';
+
+    public const PROPERTY_OPTION_DELIMITER = ':';
+
+    public const PROPERTY_TYPE_DELIMITER = '|';
+
+    public const SETTER_CHAR = 's';
+
+    public const GETTER_CHAR = 'g';
+
+    /**
+     * @inheritdoc
+     *
+     * @return Property[]
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    public function parse(string $inputValue): array
+    {
+        $properties = [];
+        foreach ($this->getProperties($inputValue) as $propertyString) {
+            $chunks = $this->getChunks($propertyString);
+            $settersGetters = $chunks[2] ?? '';
+
+            $properties[] = new Property(
+                $this->validateName($chunks[0]),
+                $this->validateTypes($chunks[1]),
+                false !== strpos($settersGetters, self::SETTER_CHAR),
+                false !== strpos($settersGetters, self::GETTER_CHAR)
+            );
+        }
+
+        return $properties;
+    }
+
+    /**
+     * Returns properties strings.
+     *
+     * @param string $inputValue
+     *
+     * @return string[]
+     */
+    protected function getProperties(string $inputValue): array
+    {
+        return array_filter(
+            explode(
+                self::PROPERTY_DELIMITER,
+                $inputValue . self::PROPERTY_DELIMITER
+            )
+        );
+    }
+
+    /**
+     * Returns property chunks.
+     *
+     * @param string $propertyString
+     *
+     * @return array
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    protected function getChunks(string $propertyString): array
+    {
+        if (false === strpos($propertyString, self::PROPERTY_OPTION_DELIMITER)) {
+            throw new PropertyStringIsInvalid(__("Property string '%1' is invalid", $propertyString));
+        }
+
+        $chunks = explode(self::PROPERTY_OPTION_DELIMITER, $propertyString);
+        if (count($chunks) < 2) {
+            throw new PropertyStringIsInvalid(__("Property string '%1' is invalid", $propertyString));
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * Validates and returns name.
+     *
+     * @param string $name
+     *
+     * @return string
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    protected function validateName(string $name): string
+    {
+        if (!$this->validate($name)) {
+            throw new PropertyStringIsInvalid(__("Property name '%1' is invalid", $name));
+        }
+
+        return $name;
+    }
+
+    /**
+     * Validates and returns types.
+     *
+     * @param string $types
+     *
+     * @return array
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    protected function validateTypes(string $types): array
+    {
+        $filteredTypes = array_filter(
+            explode(
+                self::PROPERTY_TYPE_DELIMITER,
+                $types . self::PROPERTY_TYPE_DELIMITER
+            )
+        );
+
+        array_map(function ($type) {
+            if (!$this->validate($type)) {
+                throw new PropertyStringIsInvalid(__("Property's type '%2' is invalid", $type));
+            }
+        }, $filteredTypes);
+
+        return $filteredTypes;
+    }
+
+    /**
+     * Validates property name or type string.
+     *
+     * @param string $inputString
+     *
+     * @return bool
+     */
+    protected function validate(string $inputString): bool
+    {
+        return (bool) preg_match('/^[A-Za-z]\w+?$/', $inputString);
+    }
+}

--- a/Model/Manager/EntityManager.php
+++ b/Model/Manager/EntityManager.php
@@ -58,6 +58,12 @@ class EntityManager implements ComponentManagerInterface
                 'File location',
                 'Model'
             ),
+            new InputOption(
+                InputParameter::NAME,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Class name'
+            ),
             PropertiesOption::create(),
             new InputOption(
                 EntityCommand::COMMAND_HAS_INTERFACE_PARAMETER,

--- a/Model/Manager/EntityManager.php
+++ b/Model/Manager/EntityManager.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Manager;
+
+use Marsskom\Generator\Api\Data\ComponentManagerInterface;
+use Marsskom\Generator\Api\Data\SequenceInterface;
+use Marsskom\Generator\Api\Data\Validator\ValidationObserverInterface;
+use Marsskom\Generator\Console\Command\EntityCommand;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\GlobalFactory;
+use Marsskom\Generator\Model\InputOption\Entity\PropertiesOption;
+use Marsskom\Generator\Model\Sequence\Stub\Entity\EntitySequenceFactory;
+use Marsskom\Generator\Model\Validator\Console\ModuleValidator;
+use Marsskom\Generator\Model\Validator\Console\NameValidator;
+use Marsskom\Generator\Model\Validator\Entity\PropertiesValidator;
+use Marsskom\Generator\Model\Validator\ValidatorObserver;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+class EntityManager implements ComponentManagerInterface
+{
+    private GlobalFactory $globalFactory;
+
+    private EntitySequenceFactory $sequenceFactory;
+
+    /**
+     * Manager constructor.
+     *
+     * @param GlobalFactory         $globalFactory
+     * @param EntitySequenceFactory $sequenceFactory
+     */
+    public function __construct(
+        GlobalFactory $globalFactory,
+        EntitySequenceFactory $sequenceFactory
+    ) {
+        $this->globalFactory = $globalFactory;
+        $this->sequenceFactory = $sequenceFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function inputDefinition(): InputDefinition
+    {
+        return new InputDefinition([
+            new InputOption(
+                InputParameter::MODULE,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Module name (Vendor_Module)'
+            ),
+            new InputOption(
+                InputParameter::PATH,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'File location',
+                'Model'
+            ),
+            PropertiesOption::create(),
+            new InputOption(
+                EntityCommand::COMMAND_HAS_INTERFACE_PARAMETER,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Indicates whether to create an interface for class',
+                false
+            ),
+            new InputOption(
+                EntityCommand::COMMAND_IS_DATA_OBJECT_PARAMETER,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Indicates whether tha class extends DataObject',
+                false
+            ),
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function validationObserver(): ValidationObserverInterface
+    {
+        return new ValidatorObserver(
+            EntityCommand::EVENT_NAME,
+            [
+                $this->globalFactory->create(ModuleValidator::class),
+                $this->globalFactory->create(NameValidator::class),
+                $this->globalFactory->create(PropertiesValidator::class),
+            ]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sequence(): SequenceInterface
+    {
+        return $this->sequenceFactory->create();
+    }
+}

--- a/Model/Sequence/Stub/Automation/Filesystem/FileNameChanger.php
+++ b/Model/Sequence/Stub/Automation/Filesystem/FileNameChanger.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem;
+
+use Closure;
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+
+class FileNameChanger extends AbstractSequence
+{
+    private string $prefix;
+
+    private string $suffix;
+
+    private ?Closure $callback;
+
+    /**
+     * @inheritdoc
+     *
+     * @param string        $prefix
+     * @param string        $suffix
+     * @param null|callable $callback
+     */
+    public function __construct(
+        string $prefix = '',
+        string $suffix = '',
+        ?Closure $callback = null,
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->prefix = $prefix;
+        $this->suffix = $suffix;
+        $this->callback = $callback ??
+            static function (ContextInterface $context) {
+                return $context->getUserInput()[InputParameter::NAME] ?? '';
+            };
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        return $context->setFileName($this->getFileName($context));
+    }
+
+    /**
+     * Returns changed name.
+     *
+     * @param ContextInterface $context
+     *
+     * @return string
+     */
+    protected function getFileName(ContextInterface $context): string
+    {
+        return $this->prefix . $this->callback($context) . $this->suffix;
+    }
+}

--- a/Model/Sequence/Stub/Automation/Filesystem/FileNameChanger.php
+++ b/Model/Sequence/Stub/Automation/Filesystem/FileNameChanger.php
@@ -15,6 +15,8 @@ class FileNameChanger extends AbstractSequence
 
     private string $suffix;
 
+    private string $extension;
+
     private ?Closure $callback;
 
     /**
@@ -22,11 +24,13 @@ class FileNameChanger extends AbstractSequence
      *
      * @param string        $prefix
      * @param string        $suffix
+     * @param string        $extension
      * @param null|callable $callback
      */
     public function __construct(
         string $prefix = '',
         string $suffix = '',
+        string $extension = 'php',
         ?Closure $callback = null,
         array $sequences = []
     ) {
@@ -34,6 +38,7 @@ class FileNameChanger extends AbstractSequence
 
         $this->prefix = $prefix;
         $this->suffix = $suffix;
+        $this->extension = $extension;
         $this->callback = $callback ??
             static function (ContextInterface $context) {
                 return $context->getUserInput()[InputParameter::NAME] ?? '';
@@ -57,6 +62,6 @@ class FileNameChanger extends AbstractSequence
      */
     protected function getFileName(ContextInterface $context): string
     {
-        return $this->prefix . $this->callback($context) . $this->suffix;
+        return $this->prefix . ($this->callback)($context) . $this->suffix . '.' . $this->extension;
     }
 }

--- a/Model/Sequence/Stub/Automation/Filesystem/PathPrefixAssigner.php
+++ b/Model/Sequence/Stub/Automation/Filesystem/PathPrefixAssigner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem;
+
+use Magento\Framework\Exception\FileSystemException;
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Api\Data\Helper\PathInterface;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+use const DIRECTORY_SEPARATOR;
+
+class PathPrefixAssigner extends AbstractSequence
+{
+    private PathInterface $pathHelper;
+
+    private string $prefix;
+
+    /**
+     * @inheritdoc
+     *
+     * @param PathInterface $pathHelper
+     * @param string        $prefix
+     */
+    public function __construct(
+        PathInterface $pathHelper,
+        string $prefix = '',
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->pathHelper = $pathHelper;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws FileSystemException
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        return $context->setPath(
+            $this->pathHelper->getPathToFile(
+                $context->getUserInput()[InputParameter::MODULE],
+                $this->prefix . DIRECTORY_SEPARATOR . $context->getUserInput()[InputParameter::PATH]
+            )
+        );
+    }
+}

--- a/Model/Sequence/Stub/Automation/NamespaceGenerator.php
+++ b/Model/Sequence/Stub/Automation/NamespaceGenerator.php
@@ -6,39 +6,55 @@ namespace Marsskom\Generator\Model\Sequence\Stub\Automation;
 
 use Magento\Framework\Exception\LocalizedException;
 use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Api\Data\Helper\PathInterface;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Enum\TemplateVariable;
 use Marsskom\Generator\Model\Foundation\AbstractSequence;
 use Marsskom\Generator\Model\Helper\Builder\ModuleBuilder;
+use function str_replace;
 
 class NamespaceGenerator extends AbstractSequence
 {
+    private PathInterface $pathHelper;
+
     private ModuleBuilder $moduleBuilder;
 
     /**
      * @inheritdoc
      *
+     * @param PathInterface $pathHelper
      * @param ModuleBuilder $moduleBuilder
      */
     public function __construct(
+        PathInterface $pathHelper,
         ModuleBuilder $moduleBuilder,
         array $sequences = []
     ) {
         parent::__construct($sequences);
 
+        $this->pathHelper = $pathHelper;
         $this->moduleBuilder = $moduleBuilder;
     }
 
     /**
      * @inheritdoc
+     *
+     * @throws LocalizedException
      */
     public function execute(ContextInterface $context): ContextInterface
     {
+        $moduleName = $context->getUserInput()[InputParameter::MODULE];
+        $path = $context->getUserInput()[InputParameter::PATH];
+
+        if (!empty($context->getPath())) {
+            $modulePath = $this->pathHelper->getModulePath($moduleName);
+            $path = str_replace($modulePath, '', $context->getPath());
+        }
+
+        $namespace = $this->getNamespace($moduleName, $path);
+
         $variables = $context->getVariables();
-        $variables[TemplateVariable::FILE_NAMESPACE] = $this->getNamespace(
-            $context->getUserInput()[InputParameter::MODULE],
-            $context->getUserInput()[InputParameter::PATH]
-        );
+        $variables[TemplateVariable::FILE_NAMESPACE] = str_replace('\\\\', '\\', $namespace);
 
         return $context->setVariables($variables);
     }

--- a/Model/Sequence/Stub/Entity/ClassExtendsGenerator.php
+++ b/Model/Sequence/Stub/Entity/ClassExtendsGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Console\Command\EntityCommand;
+use Marsskom\Generator\Model\Enum\TemplateVariable;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+
+class ClassExtendsGenerator extends AbstractSequence
+{
+    /**
+     * @inheritdoc
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        if (!$context->getUserInput()[EntityCommand::COMMAND_IS_DATA_OBJECT_PARAMETER]) {
+            return $context;
+        }
+
+        $variables = $context->getVariables();
+        $variables[TemplateVariable::FILE_USES][] = 'use Magento\Framework\DataObject;';
+        $variables[TemplateVariable::CLASS_EXTENDS] = ' extends DataObject';
+
+        return $context->setVariables($variables);
+    }
+}

--- a/Model/Sequence/Stub/Entity/DataObjectExtendsGenerator.php
+++ b/Model/Sequence/Stub/Entity/DataObjectExtendsGenerator.php
@@ -9,7 +9,7 @@ use Marsskom\Generator\Console\Command\EntityCommand;
 use Marsskom\Generator\Model\Enum\TemplateVariable;
 use Marsskom\Generator\Model\Foundation\AbstractSequence;
 
-class ClassExtendsGenerator extends AbstractSequence
+class DataObjectExtendsGenerator extends AbstractSequence
 {
     /**
      * @inheritdoc

--- a/Model/Sequence/Stub/Entity/EntityClassSequence.php
+++ b/Model/Sequence/Stub/Entity/EntityClassSequence.php
@@ -33,7 +33,7 @@ class EntityClassSequence extends BufferedSequence
                 $globalFactory->create(PhpFileNameGenerator::class),
                 $globalFactory->create(NamespaceGenerator::class),
                 $globalFactory->create(ClassNameGenerator::class),
-                $globalFactory->create(ClassExtendsGenerator::class),
+                $globalFactory->create(DataObjectExtendsGenerator::class),
                 $globalFactory->create(PropertiesGenerator::class),
                 $globalFactory->create(MethodGenerator::class),
                 $globalFactory->create(EntityStubGenerator::class),

--- a/Model/Sequence/Stub/Entity/EntityClassSequence.php
+++ b/Model/Sequence/Stub/Entity/EntityClassSequence.php
@@ -8,12 +8,13 @@ use Marsskom\Generator\Model\Context\BufferBuilder;
 use Marsskom\Generator\Model\Foundation\BufferedSequence;
 use Marsskom\Generator\Model\GlobalFactory;
 use Marsskom\Generator\Model\Sequence\Automation\Writer;
-use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\FileNameChanger;
-use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\PathPrefixAssigner;
+use Marsskom\Generator\Model\Sequence\Stub\Automation\ClassNameGenerator;
+use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\PathGenerator;
+use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\PhpFileNameGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use function array_merge;
 
-class InterfaceSequence extends BufferedSequence
+class EntityClassSequence extends BufferedSequence
 {
     /**
      * @inheritdoc
@@ -28,17 +29,14 @@ class InterfaceSequence extends BufferedSequence
         parent::__construct(
             $bufferBuilder,
             array_merge([
-                $globalFactory->create(PathPrefixAssigner::class, [
-                    'prefix' => 'Api/Data',
-                ]),
-                $globalFactory->create(FileNameChanger::class, [
-                    'suffix' => 'Interface',
-                ]),
+                $globalFactory->create(PathGenerator::class),
+                $globalFactory->create(PhpFileNameGenerator::class),
                 $globalFactory->create(NamespaceGenerator::class),
+                $globalFactory->create(ClassNameGenerator::class),
+                $globalFactory->create(ClassExtendsGenerator::class),
                 $globalFactory->create(PropertiesGenerator::class),
                 $globalFactory->create(MethodGenerator::class),
-                $globalFactory->create(InterfaceGenerator::class),
-                $globalFactory->create(InterfaceStubGenerator::class),
+                $globalFactory->create(EntityStubGenerator::class),
                 $globalFactory->create(Writer::class),
             ], $sequences)
         );

--- a/Model/Sequence/Stub/Entity/EntitySequence.php
+++ b/Model/Sequence/Stub/Entity/EntitySequence.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Model\Foundation\Sequence;
+use Marsskom\Generator\Model\GlobalFactory;
+use function array_merge;
+
+class EntitySequence extends Sequence
+{
+    /**
+     * @inheritdoc
+     *
+     * @param GlobalFactory $globalFactory
+     */
+    public function __construct(
+        GlobalFactory $globalFactory,
+        array $sequences = []
+    ) {
+        parent::__construct(array_merge([
+            $globalFactory->create(InterfaceSequence::class),
+        ], $sequences));
+    }
+}

--- a/Model/Sequence/Stub/Entity/EntitySequence.php
+++ b/Model/Sequence/Stub/Entity/EntitySequence.php
@@ -21,6 +21,7 @@ class EntitySequence extends Sequence
     ) {
         parent::__construct(array_merge([
             $globalFactory->create(InterfaceSequence::class),
+            $globalFactory->create(EntityClassSequence::class),
         ], $sequences));
     }
 }

--- a/Model/Sequence/Stub/Entity/EntityStubGenerator.php
+++ b/Model/Sequence/Stub/Entity/EntityStubGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Model\Foundation\StubGenerator;
+
+class EntityStubGenerator extends StubGenerator
+{
+    /**
+     * @inheritdoc
+     */
+    public function getStubName(): string
+    {
+        return 'entity/entity.stub';
+    }
+}

--- a/Model/Sequence/Stub/Entity/InterfaceGenerator.php
+++ b/Model/Sequence/Stub/Entity/InterfaceGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\Enum\TemplateVariable;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+
+class InterfaceGenerator extends AbstractSequence
+{
+    /**
+     * @inheritdoc
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        $variables = $context->getVariables();
+        $variables[TemplateVariable::INTERFACE_NAME] = $context->getUserInput()[InputParameter::NAME] . 'Interface';
+
+        return $context->setVariables($variables);
+    }
+}

--- a/Model/Sequence/Stub/Entity/InterfaceSequence.php
+++ b/Model/Sequence/Stub/Entity/InterfaceSequence.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Model\Foundation\Sequence;
+use Marsskom\Generator\Model\GlobalFactory;
+use Marsskom\Generator\Model\Sequence\Automation\Writer;
+use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\FileNameChanger;
+use Marsskom\Generator\Model\Sequence\Stub\Automation\Filesystem\PathPrefixAssigner;
+use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
+use function array_merge;
+
+class InterfaceSequence extends Sequence
+{
+    /**
+     * @inheritdoc
+     *
+     * @param GlobalFactory $globalFactory
+     */
+    public function __construct(
+        GlobalFactory $globalFactory,
+        array $sequences = []
+    ) {
+        parent::__construct(array_merge([
+            $globalFactory->create(PathPrefixAssigner::class, [
+                'prefix' => 'Api/Data',
+            ]),
+            $globalFactory->create(FileNameChanger::class, [
+                'suffix' => 'Interface',
+            ]),
+            $globalFactory->create(NamespaceGenerator::class),
+            $globalFactory->create(InterfaceStubGenerator::class),
+            $globalFactory->create(Writer::class),
+        ], $sequences));
+    }
+}

--- a/Model/Sequence/Stub/Entity/InterfaceSequence.php
+++ b/Model/Sequence/Stub/Entity/InterfaceSequence.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
 
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Console\Command\EntityCommand;
 use Marsskom\Generator\Model\Context\BufferBuilder;
 use Marsskom\Generator\Model\Foundation\BufferedSequence;
 use Marsskom\Generator\Model\GlobalFactory;
@@ -42,5 +44,17 @@ class InterfaceSequence extends BufferedSequence
                 $globalFactory->create(Writer::class),
             ], $sequences)
         );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        if (empty($context->getUserInput()[EntityCommand::COMMAND_HAS_INTERFACE_PARAMETER])) {
+            return $context;
+        }
+
+        return parent::execute($context);
     }
 }

--- a/Model/Sequence/Stub/Entity/InterfaceStubGenerator.php
+++ b/Model/Sequence/Stub/Entity/InterfaceStubGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Model\Foundation\StubGenerator;
+
+class InterfaceStubGenerator extends StubGenerator
+{
+    /**
+     * @inheritdoc
+     */
+    public function getStubName(): string
+    {
+        return 'entity/interface.stub';
+    }
+}

--- a/Model/Sequence/Stub/Entity/MethodGenerator.php
+++ b/Model/Sequence/Stub/Entity/MethodGenerator.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Exception\Entity\PropertyStringIsInvalid;
+use Marsskom\Generator\Model\Entity\Property;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\Enum\TemplateVariable;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+use Marsskom\Generator\Model\InputParser\Entity\PropertiesParser;
+use function array_filter;
+use function array_values;
+use function implode;
+use function ucfirst;
+
+class MethodGenerator extends AbstractSequence
+{
+    private PropertiesParser $parser;
+
+    /**
+     * @inheritdoc
+     *
+     * @param PropertiesParser $parser
+     */
+    public function __construct(
+        PropertiesParser $parser,
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->parser = $parser;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        $propsObjects = $this->parser->parse(
+            $context->getUserInput()[InputParameter::PROPERTIES] ?? ''
+        );
+
+        $methods = [];
+        foreach ($propsObjects as $property) {
+            $methods[] = $this->createSetter($property);
+            $methods[] = $this->createGetter($property);
+        }
+
+        $variables = $context->getVariables();
+        $variables[TemplateVariable::METHODS] = array_values(array_filter($methods));
+
+        return $context->setVariables($variables);
+    }
+
+    /**
+     * Creates set method.
+     *
+     * @param Property $property
+     *
+     * @return array
+     */
+    private function createSetter(Property $property): array
+    {
+        if (!$property->hasSetter()) {
+            return [];
+        }
+
+        $name = $property->getName();
+        $types = implode('|', $property->getTypes());
+
+        return [
+            'annotation'  => '',
+            'name'        => 'set' . ucfirst($name),
+            'parameters'  => $types . ' $' . $name,
+            'return_type' => 'static',
+            'body'        => '$this->' . $name . ' = $' . $name . ';',
+        ];
+    }
+
+    /**
+     * Creates get method.
+     *
+     * @param Property $property
+     *
+     * @return array
+     */
+    private function createGetter(Property $property): array
+    {
+        if (!$property->hasGetter()) {
+            return [];
+        }
+
+        return [
+            'annotation'  => '',
+            'name'        => 'get' . ucfirst($property->getName()),
+            'parameters'  => '',
+            'return_type' => implode('|', $property->getTypes()),
+            'body'        => 'return $this->' . $property->getName() . ';',
+        ];
+    }
+}

--- a/Model/Sequence/Stub/Entity/MethodGenerator.php
+++ b/Model/Sequence/Stub/Entity/MethodGenerator.php
@@ -52,6 +52,7 @@ class MethodGenerator extends AbstractSequence
         }
 
         $variables = $context->getVariables();
+        // `array_values` is required here for reindex the keys that is important for mustache template engine.
         $variables[TemplateVariable::METHODS] = array_values(array_filter($methods));
 
         return $context->setVariables($variables);

--- a/Model/Sequence/Stub/Entity/PropertiesGenerator.php
+++ b/Model/Sequence/Stub/Entity/PropertiesGenerator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Exception\Entity\PropertyStringIsInvalid;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\Enum\TemplateVariable;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+use Marsskom\Generator\Model\InputParser\Entity\PropertiesParser;
+use function implode;
+
+class PropertiesGenerator extends AbstractSequence
+{
+    private PropertiesParser $parser;
+
+    /**
+     * @inheritdoc
+     *
+     * @param PropertiesParser $parser
+     */
+    public function __construct(
+        PropertiesParser $parser,
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->parser = $parser;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    public function execute(ContextInterface $context): ContextInterface
+    {
+        $propsObjects = $this->parser->parse(
+            $context->getUserInput()[InputParameter::PROPERTIES] ?? ''
+        );
+
+        $properties = [];
+        foreach ($propsObjects as $property) {
+            $properties[] = 'private ' . implode('|', $property->getTypes()) . ' $' . $property->getName() . ';';
+        }
+
+        $variables = $context->getVariables();
+        $variables[TemplateVariable::CLASS_PROPERTIES] = $properties;
+
+        return $context->setVariables($variables);
+    }
+}

--- a/Model/Sequence/Stub/Entity/PropertiesGenerator.php
+++ b/Model/Sequence/Stub/Entity/PropertiesGenerator.php
@@ -6,6 +6,7 @@ namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
 
 use Marsskom\Generator\Api\Data\Context\ContextInterface;
 use Marsskom\Generator\Exception\Entity\PropertyStringIsInvalid;
+use Marsskom\Generator\Model\Entity\Property;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Enum\TemplateVariable;
 use Marsskom\Generator\Model\Foundation\AbstractSequence;
@@ -43,12 +44,24 @@ class PropertiesGenerator extends AbstractSequence
 
         $properties = [];
         foreach ($propsObjects as $property) {
-            $properties[] = 'private ' . implode('|', $property->getTypes()) . ' $' . $property->getName() . ';';
+            $properties[] = $this->getPropertyString($property);
         }
 
         $variables = $context->getVariables();
         $variables[TemplateVariable::CLASS_PROPERTIES] = $properties;
 
         return $context->setVariables($variables);
+    }
+
+    /**
+     * Returns property as string.
+     *
+     * @param Property $property
+     *
+     * @return string
+     */
+    protected function getPropertyString(Property $property): string
+    {
+        return 'private ' . implode('|', $property->getTypes()) . ' $' . $property->getName() . ';';
     }
 }

--- a/Model/Validator/Entity/PropertiesValidator.php
+++ b/Model/Validator/Entity/PropertiesValidator.php
@@ -36,7 +36,6 @@ class PropertiesValidator extends Validator
     protected function concreteValidate(array $userInput): void
     {
         $propertiesString = $userInput[InputParameter::PROPERTIES] ?? '';
-
         if (empty($propertiesString)) {
             return;
         }

--- a/Model/Validator/Entity/PropertiesValidator.php
+++ b/Model/Validator/Entity/PropertiesValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Validator\Entity;
+
+use Marsskom\Generator\Api\Data\Validator\ValidatorInterface;
+use Marsskom\Generator\Exception\Entity\PropertyStringIsInvalid;
+use Marsskom\Generator\Exception\ValidateException;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\InputParser\Entity\PropertiesParser;
+use Marsskom\Generator\Model\Validator\Validator;
+
+class PropertiesValidator extends Validator
+{
+    private PropertiesParser $parser;
+
+    /**
+     * Validator constructor.
+     *
+     * @param PropertiesParser        $parser
+     * @param null|ValidatorInterface $next
+     */
+    public function __construct(
+        PropertiesParser $parser,
+        ?ValidatorInterface $next = null
+    ) {
+        parent::__construct($next);
+
+        $this->parser = $parser;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function concreteValidate(array $userInput): void
+    {
+        $propertiesString = $userInput[InputParameter::PROPERTIES] ?? '';
+
+        if (empty($propertiesString)) {
+            return;
+        }
+
+        try {
+            $this->parser->parse($propertiesString);
+        } catch (PropertyStringIsInvalid $exception) {
+            throw new ValidateException(__($exception->getMessage()));
+        }
+    }
+}

--- a/Test/Unit/Foundation/BufferedSequenceTest.php
+++ b/Test/Unit/Foundation/BufferedSequenceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Test\Unit\Foundation;
+
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Model\Context\BufferBuilder;
+use Marsskom\Generator\Model\Enum\InputParameter;
+use Marsskom\Generator\Model\Foundation\BufferedSequence;
+use Marsskom\Generator\Test\Unit\Mock\Sequence\SimpleSequence;
+use Marsskom\Generator\Test\Unit\MockHelper\ContextFactory;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use function spl_object_id;
+
+class BufferedSequenceTest extends MockeryTestCase
+{
+    private ContextInterface $context;
+
+    /**
+     * @inheritdoc
+     */
+    protected function mockeryTestSetUp(): void
+    {
+        $this->context = (new ContextFactory())->getMockedContext(
+            [
+                InputParameter::MODULE => '',
+                InputParameter::PATH   => '',
+            ]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function mockeryTestTearDown(): void
+    {
+        unset($this->context);
+    }
+
+    /**
+     * Tests simple sequence object identities.
+     *
+     * @return void
+     */
+    public function testSequenceObjectIds(): void
+    {
+        $string = '0123456789';
+        $sequence = new SimpleSequence($string);
+        $context = $sequence->execute($this->context);
+
+        $this->assertEquals(
+            spl_object_id($this->context),
+            spl_object_id($context),
+        );
+    }
+
+    /**
+     * Tests buffered sequence object identities.
+     *
+     * @return void
+     */
+    public function testBufferedSequenceObjectIds(): void
+    {
+        $sequence = new BufferedSequence(new BufferBuilder());
+        $context = $sequence->execute($this->context);
+
+        $this->assertNotEquals(
+            spl_object_id($this->context),
+            spl_object_id($context),
+        );
+    }
+}

--- a/Test/Unit/InputParser/PropertiesParserTest.php
+++ b/Test/Unit/InputParser/PropertiesParserTest.php
@@ -19,15 +19,15 @@ class PropertiesParserTest extends MockeryTestCase
      */
     public function testSimpleProperty(): void
     {
-        $string = "id:int|null:sg";
+        $string = "id:?|int:sg";
         $properties = (new PropertiesParser())->parse($string);
         $idProperty = $properties[0];
 
         $this->assertEquals('id', $idProperty->getName());
 
         $this->assertIsArray($idProperty->getTypes());
+        $this->assertContains('?', $idProperty->getTypes());
         $this->assertContains('int', $idProperty->getTypes());
-        $this->assertContains('null', $idProperty->getTypes());
 
         $this->assertTrue($idProperty->hasGetter());
         $this->assertTrue($idProperty->hasSetter());

--- a/Test/Unit/InputParser/PropertiesParserTest.php
+++ b/Test/Unit/InputParser/PropertiesParserTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Test\Unit\InputParser;
+
+use Marsskom\Generator\Exception\Entity\PropertyStringIsInvalid;
+use Marsskom\Generator\Model\InputParser\Entity\PropertiesParser;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class PropertiesParserTest extends MockeryTestCase
+{
+    /**
+     * Tests simple property.
+     *
+     * @return void
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    public function testSimpleProperty(): void
+    {
+        $string = "id:int|null:sg";
+        $properties = (new PropertiesParser())->parse($string);
+        $idProperty = $properties[0];
+
+        $this->assertEquals('id', $idProperty->getName());
+
+        $this->assertIsArray($idProperty->getTypes());
+        $this->assertContains('int', $idProperty->getTypes());
+        $this->assertContains('null', $idProperty->getTypes());
+
+        $this->assertTrue($idProperty->hasGetter());
+        $this->assertTrue($idProperty->hasSetter());
+    }
+
+    /**
+     * Tests multiple properties.
+     *
+     * @return void
+     *
+     * @throws PropertyStringIsInvalid
+     */
+    public function testMultipleProperties(): void
+    {
+        $string = "key:int:s;value:string:g";
+        $properties = (new PropertiesParser())->parse($string);
+        $this->assertCount(2, $properties);
+
+        $keyProperty = $properties[0];
+
+        $this->assertEquals('key', $keyProperty->getName());
+
+        $this->assertIsArray($keyProperty->getTypes());
+        $this->assertContains('int', $keyProperty->getTypes());
+        $this->assertCount(1, $keyProperty->getTypes());
+
+        $this->assertFalse($keyProperty->hasGetter());
+        $this->assertTrue($keyProperty->hasSetter());
+
+        $valueProperty = $properties[1];
+
+        $this->assertEquals('value', $valueProperty->getName());
+
+        $this->assertIsArray($valueProperty->getTypes());
+        $this->assertContains('string', $valueProperty->getTypes());
+        $this->assertCount(1, $valueProperty->getTypes());
+
+        $this->assertTrue($valueProperty->hasGetter());
+        $this->assertFalse($valueProperty->hasSetter());
+    }
+
+    /**
+     * Test exception.
+     *
+     * @param string $inputString
+     *
+     * @return void
+     *
+     * @dataProvider exceptionDataProvided
+     */
+    public function testException(string $inputString): void
+    {
+        $this->expectException(PropertyStringIsInvalid::class);
+
+        (new PropertiesParser())->parse($inputString);
+    }
+
+    /**
+     * Data provided that generates exception.
+     *
+     * @return string[][]
+     */
+    public function exceptionDataProvided(): array
+    {
+        return [
+            ["key"],
+            ["key;value"],
+            ["key|type"],
+            ["key|type:g"],
+            ["2name:int:sg"],
+            ["name:type :g"],
+            ["name:2type :g"],
+            ["na%me:t\$ype :g"],
+        ];
+    }
+}

--- a/Test/Unit/Stub/Automation/NamespaceGeneratorTest.php
+++ b/Test/Unit/Stub/Automation/NamespaceGeneratorTest.php
@@ -4,10 +4,12 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Test\Unit\Stub\Automation;
 
+use Magento\Framework\Exception\LocalizedException;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Enum\TemplateVariable;
 use Marsskom\Generator\Model\Helper\Builder\ModuleBuilder;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
+use Marsskom\Generator\Test\Unit\Mock\Helper\Path;
 use Marsskom\Generator\Test\Unit\MockHelper\ContextFactory;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
@@ -17,10 +19,12 @@ class NamespaceGeneratorTest extends MockeryTestCase
      * Tests namespace.
      *
      * @return void
+     *
+     * @throws LocalizedException
      */
     public function testExecute(): void
     {
-        $namespaceGenerator = new NamespaceGenerator(new ModuleBuilder());
+        $namespaceGenerator = new NamespaceGenerator(new Path(), new ModuleBuilder());
 
         $context = $namespaceGenerator->execute(
             (new ContextFactory())->getMockedContext([

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -30,6 +30,8 @@
                       xsi:type="object">Marsskom\Generator\Console\Command\Patch\DataPatchCommand</item>
                 <item name="generatorConsoleCommand"
                       xsi:type="object">Marsskom\Generator\Console\Command\Console\ConsoleCommandCommand</item>
+                <item name="generatorEntityCommand"
+                      xsi:type="object">Marsskom\Generator\Console\Command\EntityCommand</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -35,23 +35,4 @@
             </argument>
         </arguments>
     </type>
-
-    <type name="Marsskom\Generator\Console\Command\ModuleCommand">
-        <arguments>
-            <argument name="componentManager"
-                      xsi:type="object">Marsskom\Generator\Model\Manager\ModuleManager</argument>
-        </arguments>
-    </type>
-    <type name="Marsskom\Generator\Console\Command\Patch\DataPatchCommand">
-        <arguments>
-            <argument name="componentManager"
-                      xsi:type="object">Marsskom\Generator\Model\Manager\Patch\DataPatchManager</argument>
-        </arguments>
-    </type>
-    <type name="Marsskom\Generator\Console\Command\Console\ConsoleCommandCommand">
-        <arguments>
-            <argument name="componentManager"
-                      xsi:type="object">Marsskom\Generator\Model\Manager\Console\CommandManager</argument>
-        </arguments>
-    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -20,6 +20,7 @@
 
     <type name="Marsskom\Generator\Model\Validator\Console\ModuleValidator" shared="false"/>
     <type name="Marsskom\Generator\Model\Validator\Console\NameValidator" shared="false"/>
+    <type name="Marsskom\Generator\Model\Validator\Entity\PropertiesValidator" shared="false"/>
 
     <type name="Magento\Framework\Console\CommandList">
         <arguments>

--- a/stubs/entity/entity.stub
+++ b/stubs/entity/entity.stub
@@ -1,0 +1,20 @@
+{{> php_file_header }}
+{{# class_annotation }}
+{{{ class_annotation }}}
+{{/ class_annotation }}
+class {{{ class_name }}}{{{ class_extends }}}{{{ class_implements }}}
+{
+    {{# properties }}
+    {{{ . }}}
+
+    {{/ properties }}
+    {{# methods }}
+    {{# annotation }}
+    {{{ annotation }}}
+    {{/ annotation }}
+    public function {{{ name }}}({{{ parameters }}}): {{{ return_type }}}
+    {
+        {{{ body }}}
+    }
+    {{/ methods }}
+}

--- a/stubs/entity/entity.stub
+++ b/stubs/entity/entity.stub
@@ -4,11 +4,11 @@
 {{/ class_annotation }}
 class {{{ class_name }}}{{{ class_extends }}}{{{ class_implements }}}
 {
-    {{# properties }}
+    {{# class_properties }}
     {{{ . }}}
-
-    {{/ properties }}
+    {{/ class_properties }}
     {{# methods }}
+
     {{# annotation }}
     {{{ annotation }}}
     {{/ annotation }}

--- a/stubs/entity/interface.stub
+++ b/stubs/entity/interface.stub
@@ -1,0 +1,13 @@
+{{> php_file_header }}
+{{# interface_annotation }}
+{{{ interface_annotation }}}
+{{/ interface_annotation }}
+interface {{{ interface_name }}}{{{ interface_extends }}}
+{
+    {{# methods }}
+    {{# annotation }}
+    {{{ annotation }}}
+    {{/ annotation }}
+    public function {{{ name }}}({{{ parameters }}}): {{{ return_type }}};
+    {{/ methods }}
+}

--- a/stubs/entity/interface.stub
+++ b/stubs/entity/interface.stub
@@ -2,7 +2,7 @@
 {{# interface_annotation }}
 {{{ interface_annotation }}}
 {{/ interface_annotation }}
-interface {{{ interface_name }}}{{{ interface_extends }}}
+interface {{{ interface_name }}}
 {
     {{# methods }}
     {{# annotation }}

--- a/stubs/partials/php_file_header.stub
+++ b/stubs/partials/php_file_header.stub
@@ -1,6 +1,14 @@
 <?php
+{{# file_annotation }}
 {{{ file_annotation }}}
+{{/ file_annotation }}
+
 
 declare(strict_types = 1);
 
 namespace {{{ file_namespace }}};
+
+{{# file_uses }}
+{{{ . }}}
+
+{{/ file_uses }}

--- a/stubs/partials/php_file_header.stub
+++ b/stubs/partials/php_file_header.stub
@@ -3,7 +3,6 @@
 {{{ file_annotation }}}
 {{/ file_annotation }}
 
-
 declare(strict_types = 1);
 
 namespace {{{ file_namespace }}};


### PR DESCRIPTION
##  Entity generator #10 

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Type          | feature             |
| License       | OSL 3.2                                                         |

### Summary (*)

**1**

+ Added beffered sequence that keeps original context for next sequence.
	The context - that is changed - is alive only children sequences/generators.
	Created test for buffered sequence.

+ Updated namespace generator and test.

+ Updated `EntityCommand` - moved manager into **constructor**, and `di.xml`.

+ Updated stubs.

**2**

+ Renamed `ClassExtendsGenerator` because this generator handles only with **DataObject**.

**3**

+ Updated properties parser test.

**4**

+ Moved component managers from di directly into constructors.

+ Cleared `di.xml`.


### Related Issues

#10 
