### PR TITLE
The stub writer improvement (#49)

### DIFF
--- a/Api/Data/Scope/ScopeInterface.php
+++ b/Api/Data/Scope/ScopeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Api\Data\Scope;
 
+use Generator;
 use Marsskom\Generator\Api\Data\Command\InterruptInterface;
 use Marsskom\Generator\Api\Data\Context\ContextInterface;
 
@@ -81,4 +82,11 @@ interface ScopeInterface
      * @return ScopeVariableInterface
      */
     public function for(string $contextAlias): ScopeVariableInterface;
+
+    /**
+     * Walks through all context, returns scope with each context and doesn't change original scope.
+     *
+     * @return Generator
+     */
+    public function walk(): Generator;
 }

--- a/Model/Manager/ModuleManager.php
+++ b/Model/Manager/ModuleManager.php
@@ -11,6 +11,7 @@ use Marsskom\Generator\Console\Command\ModuleCommand;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
+use Marsskom\Generator\Model\Sequence\Automation\Writer\ScopeWriter;
 use Marsskom\Generator\Model\Sequence\Stub\Module\ModuleContextRegister;
 use Marsskom\Generator\Model\Sequence\Stub\Module\ModuleFileSequence;
 use Marsskom\Generator\Model\Sequence\Stub\Module\RegistrationSequence;
@@ -71,6 +72,7 @@ class ModuleManager implements ComponentManagerInterface
             $this->globalFactory->create(ModuleContextRegister::class),
             $this->globalFactory->create(RegistrationSequence::class),
             $this->globalFactory->create(ModuleFileSequence::class),
+            $this->globalFactory->create(ScopeWriter::class),
         ]);
     }
 }

--- a/Model/Manager/Patch/DataPatchManager.php
+++ b/Model/Manager/Patch/DataPatchManager.php
@@ -11,7 +11,7 @@ use Marsskom\Generator\Console\Command\Patch\DataPatchCommand;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
-use Marsskom\Generator\Model\Sequence\Automation\Writer;
+use Marsskom\Generator\Model\Sequence\Automation\Writer\ContextWriter;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ClassNameGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Patch\DataPatchContextRegister;
@@ -92,7 +92,7 @@ class DataPatchManager implements ComponentManagerInterface
             $this->globalFactory->create(NamespaceGenerator::class),
             $this->globalFactory->create(ClassNameGenerator::class),
             $this->globalFactory->create(DataPatchGenerator::class),
-            $this->globalFactory->create(Writer::class),
+            $this->globalFactory->create(ContextWriter::class),
         ]);
     }
 }

--- a/Model/Scope/Scope.php
+++ b/Model/Scope/Scope.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Model\Scope;
 
+use Generator;
 use Marsskom\Generator\Api\Data\CloneableInterface;
 use Marsskom\Generator\Api\Data\Command\InterruptInterface;
 use Marsskom\Generator\Api\Data\Context\ContextInterface;
@@ -179,6 +180,31 @@ class Scope implements ScopeInterface, CloneableInterface
         }
 
         return $this->variables[$contextId];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws ContextNotFound
+     *
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     */
+    public function walk(): Generator
+    {
+        $clonedScope = clone $this;
+
+        foreach ($clonedScope->aliases as $alias => $context) {
+            if (ScopeInterface::DEFAULT_CONTEXT === $alias) {
+                // Skips default scope that will set as last.
+                continue;
+            }
+
+            $clonedScope->setCurrentContextFromAlias($alias);
+            yield $clonedScope;
+        }
+
+        $clonedScope->setCurrentContextFromAlias(ScopeInterface::DEFAULT_CONTEXT);
+        yield $clonedScope;
     }
 
     /**

--- a/Model/Sequence/Automation/Writer/ContextWriter.php
+++ b/Model/Sequence/Automation/Writer/ContextWriter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Marsskom\Generator\Model\Sequence\Automation;
+namespace Marsskom\Generator\Model\Sequence\Automation\Writer;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
@@ -12,7 +12,7 @@ use Marsskom\Generator\Model\Foundation\AbstractSequence;
 use function implode;
 use const DIRECTORY_SEPARATOR;
 
-class Writer extends AbstractSequence
+class ContextWriter extends AbstractSequence
 {
     private Filesystem $filesystem;
 

--- a/Model/Sequence/Automation/Writer/ScopeWriter.php
+++ b/Model/Sequence/Automation/Writer/ScopeWriter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Automation\Writer;
+
+use Magento\Framework\Exception\FileSystemException;
+use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+
+class ScopeWriter extends AbstractSequence
+{
+    private ContextWriter $contextWriter;
+
+    /**
+     * @inheritdoc
+     *
+     * @param ContextWriter $contextWriter
+     */
+    public function __construct(
+        ContextWriter $contextWriter,
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->contextWriter = $contextWriter;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws FileSystemException
+     */
+    public function execute(ScopeInterface $scope): ScopeInterface
+    {
+        foreach ($scope->walk() as $concreteScope) {
+            $this->contextWriter->execute($concreteScope);
+        }
+
+        return $scope;
+    }
+}

--- a/Model/Sequence/Stub/Console/CommandSequence.php
+++ b/Model/Sequence/Stub/Console/CommandSequence.php
@@ -6,7 +6,7 @@ namespace Marsskom\Generator\Model\Sequence\Stub\Console;
 
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
-use Marsskom\Generator\Model\Sequence\Automation\Writer;
+use Marsskom\Generator\Model\Sequence\Automation\Writer\ContextWriter;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ClassNameGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use function array_merge;
@@ -28,7 +28,7 @@ class CommandSequence extends Sequence
             $globalFactory->create(ClassNameGenerator::class),
             $globalFactory->create(CommandGenerator::class),
             $globalFactory->create(CommandStubGenerator::class),
-            $globalFactory->create(Writer::class),
+            $globalFactory->create(ContextWriter::class),
         ], $sequences));
     }
 }

--- a/Model/Sequence/Stub/Entity/EntityClassSequence.php
+++ b/Model/Sequence/Stub/Entity/EntityClassSequence.php
@@ -5,11 +5,9 @@ declare(strict_types = 1);
 namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
 
 use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
-use Marsskom\Generator\Model\Context\BufferBuilder;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
 use Marsskom\Generator\Model\Sequence\Automation\Context\ContextUsageGenerator;
-use Marsskom\Generator\Model\Sequence\Automation\Writer;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ClassNameGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use function array_merge;
@@ -36,7 +34,6 @@ class EntityClassSequence extends Sequence
                 $globalFactory->create(PropertiesGenerator::class),
                 $globalFactory->create(MethodGenerator::class),
                 $globalFactory->create(EntityStubGenerator::class),
-                $globalFactory->create(Writer::class),
             ], $sequences)
         );
     }

--- a/Model/Sequence/Stub/Entity/EntitySequence.php
+++ b/Model/Sequence/Stub/Entity/EntitySequence.php
@@ -6,6 +6,7 @@ namespace Marsskom\Generator\Model\Sequence\Stub\Entity;
 
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
+use Marsskom\Generator\Model\Sequence\Automation\Writer\ScopeWriter;
 use function array_merge;
 
 class EntitySequence extends Sequence
@@ -23,6 +24,7 @@ class EntitySequence extends Sequence
             $globalFactory->create(EntityContextRegister::class),
             $globalFactory->create(InterfaceSequence::class),
             $globalFactory->create(EntityClassSequence::class),
+            $globalFactory->create(ScopeWriter::class),
         ], $sequences));
     }
 }

--- a/Model/Sequence/Stub/Entity/InterfaceSequence.php
+++ b/Model/Sequence/Stub/Entity/InterfaceSequence.php
@@ -9,7 +9,6 @@ use Marsskom\Generator\Console\Command\EntityCommand;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
 use Marsskom\Generator\Model\Sequence\Automation\Context\ContextUsageGenerator;
-use Marsskom\Generator\Model\Sequence\Automation\Writer;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use function array_merge;
 
@@ -34,7 +33,6 @@ class InterfaceSequence extends Sequence
                 $globalFactory->create(InterfaceGenerator::class),
                 $globalFactory->create(MethodGenerator::class),
                 $globalFactory->create(InterfaceStubGenerator::class),
-                $globalFactory->create(Writer::class),
             ], $sequences)
         );
     }

--- a/Model/Sequence/Stub/Module/ModuleFileSequence.php
+++ b/Model/Sequence/Stub/Module/ModuleFileSequence.php
@@ -7,7 +7,6 @@ namespace Marsskom\Generator\Model\Sequence\Stub\Module;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
 use Marsskom\Generator\Model\Sequence\Automation\Context\ContextUsageGenerator;
-use Marsskom\Generator\Model\Sequence\Automation\Writer;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ModuleNameGenerator;
 
 class ModuleFileSequence extends Sequence
@@ -27,7 +26,6 @@ class ModuleFileSequence extends Sequence
             ]),
             $globalFactory->create(ModuleNameGenerator::class),
             $globalFactory->create(ModuleFileStubGenerator::class),
-            $globalFactory->create(Writer::class),
         ], $sequences));
     }
 }

--- a/Model/Sequence/Stub/Module/RegistrationSequence.php
+++ b/Model/Sequence/Stub/Module/RegistrationSequence.php
@@ -8,7 +8,6 @@ use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
 use Marsskom\Generator\Model\Sequence\Automation\Context\ContextUsageGenerator;
-use Marsskom\Generator\Model\Sequence\Automation\Writer;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ModuleNameGenerator;
 
 class RegistrationSequence extends Sequence
@@ -28,7 +27,6 @@ class RegistrationSequence extends Sequence
             ]),
             $globalFactory->create(ModuleNameGenerator::class),
             $globalFactory->create(RegistrationStubGenerator::class),
-            $globalFactory->create(Writer::class),
         ], $sequences));
     }
 }


### PR DESCRIPTION
## The stub writer improvement

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Type          | feature             |
| License       | MIT                                                         |

### Preconditions

This feature comes from PR #48 when I created global Scope, that may use many contexts, for all sequences.

Hence I created `ScopeWriter` that just get all contexts and writes them into files.

### Summary (*)

+ Renamed `Writer` to `ContextWriter` 'cause it write only current context.
	Also moved it into sub-directory `Writer`.

+ Added **Scope** writer that walks through all contexts and uses `ContextWriter` for writing each.

+ Updated sequences: simple keeps `ContextWriter`, complex - uses `ScopeWriter`.

### Related Issues

#49 
