### PR TITLE
Add `XmlWriter`.

### DIFF
--- a/Api/Data/Command/InterruptInterface.php
+++ b/Api/Data/Command/InterruptInterface.php
@@ -25,4 +25,15 @@ interface InterruptInterface
      * @return void
      */
     public function info(Phrase $information): void;
+
+    /**
+     * Sends choose question and interrupts stream for user answer.
+     *
+     * @param Phrase $question
+     * @param array  $choices
+     * @param mixed  $default
+     *
+     * @return string
+     */
+    public function choose(Phrase $question, array $choices, $default = null): string;
 }

--- a/Api/Data/Generator/Writer/FileExtensionSeparatorInterface.php
+++ b/Api/Data/Generator/Writer/FileExtensionSeparatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Api\Data\Generator\Writer;
+
+interface FileExtensionSeparatorInterface
+{
+    /**
+     * Returns valid extensions list that writer could manage.
+     *
+     * @return string[]
+     */
+    public function validExtensions(): array;
+}

--- a/Model/Console/Interrupt.php
+++ b/Model/Console/Interrupt.php
@@ -9,6 +9,7 @@ use Marsskom\Generator\Api\Data\Command\InterruptInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class Interrupt implements InterruptInterface
@@ -46,5 +47,20 @@ class Interrupt implements InterruptInterface
     public function info(Phrase $information): void
     {
         $this->output->writeln((string) $information);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function choose(Phrase $question, array $choices, $default = null): string
+    {
+        $choiceQuestion = new ChoiceQuestion(
+            (string) $question,
+            $choices,
+            $default
+        );
+
+        return (new QuestionHelper())
+            ->ask($this->input, $this->output, $choiceQuestion);
     }
 }

--- a/Model/Helper/Writer/XmlWriteHelper.php
+++ b/Model/Helper/Writer/XmlWriteHelper.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Helper\Writer;
+
+use DOMDocument;
+use function implode;
+
+class XmlWriteHelper
+{
+    /**
+     * Extracts content from xml document.
+     *
+     * @param string $xmlDocument
+     *
+     * @return string
+     */
+    public function extract(string $xmlDocument): string
+    {
+        $document = new DOMDocument();
+        $document->loadXML($xmlDocument);
+
+        $result = [];
+        foreach ($document->documentElement->childNodes as $node) {
+            $result[] = $document->saveXML($node);
+        }
+
+        return implode('', $result);
+    }
+
+    /**
+     * Appends content into xml document.
+     *
+     * @param string $xmlDocument
+     * @param string $xmlContent
+     *
+     * @return string
+     */
+    public function append(string $xmlDocument, string $xmlContent): string
+    {
+        $document = new DOMDocument();
+        $document->loadXML($xmlDocument);
+
+        $fragment = $document->createDocumentFragment();
+        $fragment->appendXML($xmlContent);
+
+        $document->documentElement->appendChild($fragment);
+
+        return $document->saveXML();
+    }
+}

--- a/Model/InputQuestion/Writer/FileExistsActionQuestion.php
+++ b/Model/InputQuestion/Writer/FileExistsActionQuestion.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\InputQuestion\Writer;
+
+use Magento\Framework\Phrase;
+
+class FileExistsActionQuestion
+{
+    public const ACTION_APPEND = 'append';
+
+    public const ACTION_OVERWRITE = 'overwrite';
+
+    public const ACTION_SKIP = 'skip';
+
+    private Phrase $question;
+
+    private array $choices;
+
+    /**
+     * Default choice.
+     *
+     * @var mixed
+     */
+    private $default;
+
+    /**
+     * File exists action question constructor.
+     *
+     * @param Phrase     $question
+     * @param null|array $choices
+     * @param mixed      $default
+     */
+    public function __construct(Phrase $question, array $choices = null, $default = null)
+    {
+        $this->question = $question;
+        $this->choices = $choices ?? [self::ACTION_APPEND, self::ACTION_OVERWRITE, self::ACTION_SKIP];
+        $this->default = $default ?? 0;
+    }
+
+    /**
+     * Returns question.
+     *
+     * @return Phrase
+     */
+    public function getQuestion(): Phrase
+    {
+        return $this->question;
+    }
+
+    /**
+     * Returns choices.
+     *
+     * @return array
+     */
+    public function getChoices(): array
+    {
+        return $this->choices;
+    }
+
+    /**
+     * Returns default choice.
+     *
+     * @return mixed
+     */
+    public function getDefault()
+    {
+        return $this->default;
+    }
+}

--- a/Model/Manager/Patch/DataPatchManager.php
+++ b/Model/Manager/Patch/DataPatchManager.php
@@ -11,7 +11,7 @@ use Marsskom\Generator\Console\Command\Patch\DataPatchCommand;
 use Marsskom\Generator\Model\Enum\InputParameter;
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
-use Marsskom\Generator\Model\Sequence\Automation\Writer\ContextWriter;
+use Marsskom\Generator\Model\Sequence\Automation\Writer\PhpWriter;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ClassNameGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Patch\DataPatchContextRegister;
@@ -92,7 +92,7 @@ class DataPatchManager implements ComponentManagerInterface
             $this->globalFactory->create(NamespaceGenerator::class),
             $this->globalFactory->create(ClassNameGenerator::class),
             $this->globalFactory->create(DataPatchGenerator::class),
-            $this->globalFactory->create(ContextWriter::class),
+            $this->globalFactory->create(PhpWriter::class),
         ]);
     }
 }

--- a/Model/Scope/Scope.php
+++ b/Model/Scope/Scope.php
@@ -208,7 +208,7 @@ class Scope implements ScopeInterface, CloneableInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function __clone()
     {

--- a/Model/Sequence/Automation/Context/ContextRegister.php
+++ b/Model/Sequence/Automation/Context/ContextRegister.php
@@ -29,7 +29,7 @@ abstract class ContextRegister extends AbstractSequence implements ContextRegist
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function execute(ScopeInterface $scope): ScopeInterface
     {

--- a/Model/Sequence/Automation/Writer/BasedOnExtensionWriter.php
+++ b/Model/Sequence/Automation/Writer/BasedOnExtensionWriter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Automation\Writer;
+
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Filesystem\Io\File;
+use Marsskom\Generator\Api\Data\Context\ContextInterface;
+use Marsskom\Generator\Api\Data\Generator\Writer\FileExtensionSeparatorInterface;
+use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+use function array_map;
+use function in_array;
+use function strtolower;
+
+class BasedOnExtensionWriter extends AbstractSequence
+{
+    private File $file;
+
+    /**
+     * Writer constructor.
+     *
+     * @param File                              $file
+     * @param FileExtensionSeparatorInterface[] $sequences
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __construct(
+        File $file,
+        array $sequences = []
+    ) {
+        array_map(
+            static function (FileExtensionSeparatorInterface $writer) {
+            },
+            $sequences
+        );
+
+        parent::__construct($sequences);
+
+        $this->file = $file;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws FileSystemException
+     */
+    public function execute(ScopeInterface $scope): ScopeInterface
+    {
+        /** @var $child FileExtensionSeparatorInterface */
+        foreach ($this->children as $child) {
+            if (!$this->validateContextFile($scope->context(), $child->validExtensions())) {
+                continue;
+            }
+
+            $scope = $child->execute($scope);
+        }
+
+        return $scope;
+    }
+
+    /**
+     * Validates context's file.
+     *
+     * @param ContextInterface $context
+     * @param array            $validExtensions
+     *
+     * @return bool
+     */
+    protected function validateContextFile(ContextInterface $context, array $validExtensions): bool
+    {
+        $pathInfo = $this->file->getPathInfo($context->getFileName());
+
+        return in_array(strtolower($pathInfo['extension']), $validExtensions, true);
+    }
+}

--- a/Model/Sequence/Automation/Writer/PhpWriter.php
+++ b/Model/Sequence/Automation/Writer/PhpWriter.php
@@ -33,6 +33,14 @@ class PhpWriter extends AbstractSequence implements FileExtensionSeparatorInterf
 
     /**
      * @inheritdoc
+     */
+    public function validExtensions(): array
+    {
+        return ['php'];
+    }
+
+    /**
+     * @inheritdoc
      *
      * @throws FileSystemException
      */
@@ -73,13 +81,5 @@ class PhpWriter extends AbstractSequence implements FileExtensionSeparatorInterf
         }
 
         return $scope;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function validExtensions(): array
-    {
-        return ['php'];
     }
 }

--- a/Model/Sequence/Automation/Writer/PhpWriter.php
+++ b/Model/Sequence/Automation/Writer/PhpWriter.php
@@ -7,12 +7,13 @@ namespace Marsskom\Generator\Model\Sequence\Automation\Writer;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem;
+use Marsskom\Generator\Api\Data\Generator\Writer\FileExtensionSeparatorInterface;
 use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
 use Marsskom\Generator\Model\Foundation\AbstractSequence;
 use function implode;
 use const DIRECTORY_SEPARATOR;
 
-class ContextWriter extends AbstractSequence
+class PhpWriter extends AbstractSequence implements FileExtensionSeparatorInterface
 {
     private Filesystem $filesystem;
 
@@ -67,10 +68,18 @@ class ContextWriter extends AbstractSequence
 
         if ($isFileExists) {
             $scope->interrupt()->info(
-                __("File '%1' was overwrote", $fileName)
+                __("File '%1' was overwritten", $fileName)
             );
         }
 
         return $scope;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validExtensions(): array
+    {
+        return ['php'];
     }
 }

--- a/Model/Sequence/Automation/Writer/ScopeWriter.php
+++ b/Model/Sequence/Automation/Writer/ScopeWriter.php
@@ -4,37 +4,20 @@ declare(strict_types = 1);
 
 namespace Marsskom\Generator\Model\Sequence\Automation\Writer;
 
-use Magento\Framework\Exception\FileSystemException;
 use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
 use Marsskom\Generator\Model\Foundation\AbstractSequence;
 
 class ScopeWriter extends AbstractSequence
 {
-    private ContextWriter $contextWriter;
-
     /**
      * @inheritdoc
-     *
-     * @param ContextWriter $contextWriter
-     */
-    public function __construct(
-        ContextWriter $contextWriter,
-        array $sequences = []
-    ) {
-        parent::__construct($sequences);
-
-        $this->contextWriter = $contextWriter;
-    }
-
-    /**
-     * @inheritdoc
-     *
-     * @throws FileSystemException
      */
     public function execute(ScopeInterface $scope): ScopeInterface
     {
         foreach ($scope->walk() as $concreteScope) {
-            $this->contextWriter->execute($concreteScope);
+            foreach ($this->children as $child) {
+                $child->execute($concreteScope);
+            }
         }
 
         return $scope;

--- a/Model/Sequence/Automation/Writer/XmlWriter.php
+++ b/Model/Sequence/Automation/Writer/XmlWriter.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Model\Sequence\Automation\Writer;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Filesystem;
+use Marsskom\Generator\Api\Data\Generator\Writer\FileExtensionSeparatorInterface;
+use Marsskom\Generator\Api\Data\Scope\ScopeInterface;
+use Marsskom\Generator\Model\Foundation\AbstractSequence;
+use Marsskom\Generator\Model\Helper\Writer\XmlWriteHelper;
+use Marsskom\Generator\Model\InputQuestion\Writer\FileExistsActionQuestion;
+
+class XmlWriter extends AbstractSequence implements FileExtensionSeparatorInterface
+{
+    private Filesystem $filesystem;
+
+    private XmlWriteHelper $xmlWriteHelper;
+
+    /**
+     * @inheritdoc
+     *
+     * @param Filesystem     $filesystem
+     * @param XmlWriteHelper $xmlWriteHelper
+     */
+    public function __construct(
+        Filesystem $filesystem,
+        XmlWriteHelper $xmlWriteHelper,
+        array $sequences = []
+    ) {
+        parent::__construct($sequences);
+
+        $this->filesystem = $filesystem;
+        $this->xmlWriteHelper = $xmlWriteHelper;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws FileSystemException
+     */
+    public function execute(ScopeInterface $scope): ScopeInterface
+    {
+        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::APP);
+
+        $fileName = implode(
+            DIRECTORY_SEPARATOR,
+            [
+                $scope->context()->getPath(),
+                $scope->context()->getFileName(),
+            ]
+        );
+        $isFileExists = $directory->isFile($fileName);
+        if (!$isFileExists) {
+            $this->write($scope, $fileName);
+
+            return $scope;
+        }
+
+        $question = new FileExistsActionQuestion(__(
+            "File '%1' already exists. Choose the action append, overwrite, skip (default - append): ",
+            $fileName
+        ));
+        $fileAction = $scope
+            ->interrupt()
+            ->choose($question->getQuestion(), $question->getChoices(), $question->getDefault());
+
+        switch ($fileAction) {
+            case FileExistsActionQuestion::ACTION_SKIP:
+                return $scope;
+            case FileExistsActionQuestion::ACTION_OVERWRITE:
+                $this->overwrite($scope, $fileName);
+                break;
+            default:
+                $this->append($scope, $fileName);
+                break;
+        }
+
+        return $scope;
+    }
+
+    /**
+     * Writes content into file.
+     *
+     * @param ScopeInterface $scope
+     * @param string         $fileName
+     *
+     * @return void
+     *
+     * @throws FileSystemException
+     */
+    protected function write(ScopeInterface $scope, string $fileName): void
+    {
+        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::APP);
+
+        $stream = $directory->openFile($fileName);
+        $stream->lock();
+        $stream->write((string) $scope->context()->getTemplate());
+        $stream->unlock();
+        $stream->close();
+    }
+
+    /**
+     * Overwrites file.
+     *
+     * @param ScopeInterface $scope
+     * @param string         $fileName
+     *
+     * @return void
+     *
+     * @throws FileSystemException
+     */
+    protected function overwrite(ScopeInterface $scope, string $fileName): void
+    {
+        $this->write($scope, $fileName);
+
+        $scope->interrupt()->info(
+            __("File '%1' was overwritten", $fileName)
+        );
+    }
+
+    /**
+     * Appends content into existing file.
+     *
+     * @param ScopeInterface $scope
+     * @param string         $fileName
+     *
+     * @return void
+     *
+     * @throws FileSystemException
+     */
+    protected function append(ScopeInterface $scope, string $fileName): void
+    {
+        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::APP);
+
+        $xmlString = $directory->readFile($fileName);
+        $xmlContent = $this->xmlWriteHelper->extract((string) $scope->context()->getTemplate());
+        $documentString = $this->xmlWriteHelper->append($xmlString, $xmlContent);
+
+        $stream = $directory->openFile($fileName);
+        $stream->lock();
+        $stream->write($documentString);
+        $stream->unlock();
+        $stream->close();
+
+        $scope->interrupt()->info(
+            __("File '%1' was updated", $fileName)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validExtensions(): array
+    {
+        return ['xml'];
+    }
+}

--- a/Model/Sequence/Stub/Console/CommandSequence.php
+++ b/Model/Sequence/Stub/Console/CommandSequence.php
@@ -6,7 +6,7 @@ namespace Marsskom\Generator\Model\Sequence\Stub\Console;
 
 use Marsskom\Generator\Model\Foundation\Sequence;
 use Marsskom\Generator\Model\GlobalFactory;
-use Marsskom\Generator\Model\Sequence\Automation\Writer\ContextWriter;
+use Marsskom\Generator\Model\Sequence\Automation\Writer\PhpWriter;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\ClassNameGenerator;
 use Marsskom\Generator\Model\Sequence\Stub\Automation\NamespaceGenerator;
 use function array_merge;
@@ -28,7 +28,7 @@ class CommandSequence extends Sequence
             $globalFactory->create(ClassNameGenerator::class),
             $globalFactory->create(CommandGenerator::class),
             $globalFactory->create(CommandStubGenerator::class),
-            $globalFactory->create(ContextWriter::class),
+            $globalFactory->create(PhpWriter::class),
         ], $sequences));
     }
 }

--- a/Model/Validator/ValidatorObserver.php
+++ b/Model/Validator/ValidatorObserver.php
@@ -31,7 +31,7 @@ class ValidatorObserver implements ValidationObserverInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function attach(string $eventName, ValidatorInterface $validator): void
     {
@@ -51,7 +51,7 @@ class ValidatorObserver implements ValidationObserverInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function notify(string $eventName, array $userInput): ValidateResultInterface
     {

--- a/Test/Unit/Helper/XmlWriteHelperTest.php
+++ b/Test/Unit/Helper/XmlWriteHelperTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Marsskom\Generator\Test\Unit\Helper;
+
+use Marsskom\Generator\Model\Helper\Writer\XmlWriteHelper;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use function str_replace;
+
+class XmlWriteHelperTest extends MockeryTestCase
+{
+    /**
+     * Tests extract content from xml.
+     *
+     * @return void
+     */
+    public function testExtractContent(): void
+    {
+        $content = '<preference for="Test\Test\Api\Interface" type="Test\Test\Model\Model"/>
+<preference for="Test\Test\Api\Interface" type="Test\Test\Model\Model"/>';
+
+        // @codingStandardsIgnoreLine
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">' . $content . '</config>';
+
+        $helper = new XmlWriteHelper();
+
+        $this->assertEquals(
+            $content,
+            $helper->extract($xml)
+        );
+    }
+
+    /**
+     * Tests append content to xml.
+     *
+     * @return void
+     */
+    public function testAppendTest(): void
+    {
+        $xml = '<?xml version="1.0"?>
+<root><first><primary attribute="value"/></first></root>
+';
+        $content = '<test><a attribute="test"/></test><test2 attribute="value2"/>';
+
+        $helper = new XmlWriteHelper();
+
+        $this->assertEquals(
+            str_replace('</root>', $content . '</root>', $xml),
+            $helper->append($xml, $content)
+        );
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -33,6 +33,25 @@
     <type name="Marsskom\Generator\Model\Validator\Console\NameValidator" shared="false"/>
     <type name="Marsskom\Generator\Model\Validator\Entity\PropertiesValidator" shared="false"/>
 
+    <type name="Marsskom\Generator\Model\Sequence\Automation\Writer\BasedOnExtensionWriter">
+        <arguments>
+            <argument name="sequences" xsi:type="array">
+                <item name="0"
+                      xsi:type="object">Marsskom\Generator\Model\Sequence\Automation\Writer\PhpWriter</item>
+                <item name="1"
+                      xsi:type="object">Marsskom\Generator\Model\Sequence\Automation\Writer\XmlWriter</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Marsskom\Generator\Model\Sequence\Automation\Writer\ScopeWriter">
+        <arguments>
+            <argument name="sequences" xsi:type="array">
+                <item name="0"
+                      xsi:type="object">Marsskom\Generator\Model\Sequence\Automation\Writer\BasedOnExtensionWriter</item>
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Marsskom\Generator\Model\Scope\Variable\Registry">
         <arguments>
             <argument name="registriesCollections" xsi:type="array">

--- a/stubs/xml/di.stub
+++ b/stubs/xml/di.stub
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    {{# preferences }}
+    <preference for="{{{ for }}}" type="{{{ type }}}"/>
+    {{/ preferences }}
+</config>


### PR DESCRIPTION
## Add `XmlWriter`.

| Q             | A                                                           |
|---------------|-------------------------------------------------------------|
| Type          | feature             |
| License       | OSL 3.0                                                         |

### Summary (*)

+ Add `XmlWriter`.

+ Rename `ContextWriter` to `PhpWriter`.

+ Add file extension separator interface for writers.

+ Add parent writer that manages subsequence writers by extensions.

+ Add writer sequence to `ScopeWriter`.

### Related Issues

#12 
